### PR TITLE
ci(pull-request): run claude review on all PR events

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,7 +43,6 @@ jobs:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-14
 
     claude-review:
-        if: github.event.action == 'opened'
         uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-06-14
         secrets:
             CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove the `if: github.event.action == 'opened'` guard from the `claude-review` job in `pull-request.yml`.
- The reusable AI review now runs on every triggering PR event (opened, synchronize, reopened, ready_for_review) instead of only on open, so pushes to an existing PR also get reviewed.

## Test plan

- [ ] CI green on this PR
- [ ] Pushing a follow-up commit to an open PR triggers the claude-review job
