### PR TITLE
ci(pull-request): name the reusable workflow jobs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,9 +40,11 @@ jobs:
               run: ./build.sh
 
     security-secrets:
+        name: Secret Detection Scan
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-14
 
     claude-review:
+        name: Claude Code Review
         uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-06-14
         secrets:
             CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `name:` to the `security-secrets` and `claude-review` jobs in `pull-request.yml` so the Actions UI and the PR check list show "Secret Detection Scan" and "Claude Code Review" instead of the bare job keys.

## Test plan

- [ ] CI green; the two jobs render with their display names in the checks list