### PR TITLE
chore(deps): pin Sphinx build dependencies to exact versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,11 @@
 
 # Created with antsibull-docs 2.5.0.post0
 
-# Exact pins for reproducible builds; Renovate (pip manager via the org
-# renovate-base preset) bumps these as new releases land.
+# Exact pins for the direct build dependencies; Renovate (pip manager via the
+# org renovate-base preset) bumps these as new releases land. Transitive deps
+# (sphinx, antsibull-core, jinja2, ...) are intentionally not locked here — a
+# full pip-compile constraints file would be the next step if the floating
+# transitive tree ever causes drift.
 antsibull-docs==2.24.0
 ansible-pygments==0.1.2
 sphinx-ansible-theme==0.10.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@
 
 # Created with antsibull-docs 2.5.0.post0
 
-antsibull-docs >=2.24.0, <3.0.0
+# Exact pins for reproducible builds; Renovate (pip manager via the org
+# renovate-base preset) bumps these as new releases land.
+antsibull-docs==2.24.0
 ansible-pygments==0.1.2
 sphinx-ansible-theme==0.10.4
-sphinxcontrib-mermaid>=2.0.2
-sphinx-sitemap>=2.9.0
+sphinxcontrib-mermaid==2.0.2
+sphinx-sitemap==2.9.0


### PR DESCRIPTION
## Summary

- `requirements.txt` used loose lower-bound specifiers (`antsibull-docs >=2.24.0,<3.0.0`, `sphinxcontrib-mermaid>=2.0.2`, `sphinx-sitemap>=2.9.0`), so two checkouts could resolve to different versions.
- Pin all build dependencies to exact versions for reproducible builds. The pinned versions equal the current latest releases, so this is a no-functional-change hardening.
- Renovate keeps them current via the pip manager from the org `renovate-base` preset (already extended in `.github/renovate.json`).

## Test plan

- [ ] CI `Build Documentation` (incl. linkcheck) green with the pinned versions
- [ ] Secret scan green

## Notes

From the Notion "Repo Ideas" backlog for `guide`. This closes the last actionable guide idea; the remaining backlog cards (facet search, incremental builds) were closed as low-ROI.