### PR TITLE
docs(standards): document the workflow naming actually in use

### DIFF
--- a/rst/guide/best-practices/standards.rst
+++ b/rst/guide/best-practices/standards.rst
@@ -45,8 +45,10 @@ Recommended Structure
    repository/
    ├── .github/
    │   ├── workflows/
-   │   │   ├── ci.yml
-   │   │   └── publish.yml
+   │   │   ├── pull-request.yml
+   │   │   ├── merge.yml
+   │   │   ├── nightly-security.yml
+   │   │   └── tag.yml
    │   ├── ISSUE_TEMPLATE/
    │   ├── pull_request_template.md
    │   ├── CODEOWNERS
@@ -187,32 +189,66 @@ Workflow Standards
 Naming Convention
 ~~~~~~~~~~~~~~~~~
 
-* Lowercase with hyphens
-* Short and descriptive
-* Standard names: ``ci.yml``, ``publish.yml``, ``codeql.yml``, ``security.yml``
+Workflow files fall into two layers, each with its own naming rule.
+
+**Reusable workflows** live in ``arillso/.github`` and are named
+``<category>-<purpose>.yml``:
+
+* ``ci-*.yml`` - Continuous Integration
+* ``security-*.yml`` - Security scanning
+* ``release-*.yml`` - Release and publishing
+* ``cleanup-*.yml`` - Cleanup and maintenance
+* ``ai-*.yml`` - AI-assisted workflows
+
+The category prefix keeps the library navigable and lets a consumer see which
+CI it is calling. The ``name:`` field spells the purpose out in full, without
+abbreviations (``name: CI - Ansible Collection``, not ``CI Ansible``).
+
+**Caller workflows** live in each project repository and are named after the
+event that triggers them, not after the work they do:
+
+* ``pull-request.yml`` - checks on pull requests
+* ``merge.yml`` - checks after merge to ``main``
+* ``tag.yml`` - release on tag push
+* ``nightly-security.yml`` - scheduled security scans
+* ``cleanup.yml`` - scheduled maintenance
+
+A caller is thin: it wires an event to one or more reusable workflows and
+passes inputs. All names are lowercase with hyphens.
 
 Standard Workflows
 ~~~~~~~~~~~~~~~~~~
+
+Caller workflows in a project repository:
 
 .. list-table::
    :header-rows: 1
    :widths: 25 20 55
 
-   * - Workflow
+   * - Trigger
      - Filename
      - Description
-   * - CI
-     - ``ci.yml``
-     - Linting, testing, building
-   * - Publish
-     - ``publish.yml``
+   * - Pull request
+     - ``pull-request.yml``
+     - Linting and testing on pull requests
+   * - Merge
+     - ``merge.yml``
+     - Linting and testing on ``main`` after merge
+   * - Tag
+     - ``tag.yml``
      - Publish to registry + GitHub Release
-   * - Security
-     - ``security.yml``
-     - Trivy scanning
-   * - CodeQL
-     - ``codeql.yml``
-     - Code analysis (required for public repos)
+   * - Schedule
+     - ``nightly-security.yml``
+     - Security scanning, including CodeQL (required for public repos)
+   * - Schedule
+     - ``cleanup.yml``
+     - Registry retention cleanup (only where a registry is used)
+
+Not every repository needs every caller: ``tag.yml`` exists only where there is
+something to release, ``cleanup.yml`` only where a container registry is used.
+
+The reusable workflows these callers invoke are listed in
+`arillso/.github <https://github.com/arillso/.github>`_.
 
 GitHub Actions Security
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -263,7 +299,8 @@ Testing Philosophy
    with ``idempotence`` in the test sequence
 3. **Integration Tests** - ansible-test for end-to-end validation
 
-**All tests consolidated in single** ``ci.yml`` **workflow.**
+**All tests run from the event callers** (``pull-request.yml``, ``merge.yml``),
+which delegate to the shared CI workflows in ``arillso/.github``.
 
 See :ref:`cicd` for complete CI workflow implementation and :ref:`ansible-roles` for
 scenario layout, driver choice, and what ``verify.yml`` should assert.
@@ -367,7 +404,7 @@ Release Process
 
 4. **Automated workflow triggers**
 
-   * ``publish.yml`` publishes to Galaxy
+   * ``tag.yml`` publishes to Galaxy
    * Creates GitHub Release with CHANGELOG
 
 Publish Workflow
@@ -375,7 +412,7 @@ Publish Workflow
 
 **Requirements:**
 
-* Single consolidated ``publish.yml`` workflow
+* Single ``tag.yml`` caller, delegating to ``release-ansible-collection.yml``
 * Tag format without 'v' prefix: ``1.0.0`` (NOT ``v1.0.0``)
 * Validate version matches galaxy.yml
 * Check CHANGELOG entry exists
@@ -383,7 +420,7 @@ Publish Workflow
 
 **Do NOT:**
 
-* ❌ Create separate ``release.yml`` and ``publish.yml``
+* ❌ Split releasing across several callers on the same tag event
 * ❌ Use ``release: [published]`` event
 * ❌ Use 'v' prefix in tags (``1.0.0``, not ``v1.0.0``)
 

--- a/rst/guide/development/cicd.rst
+++ b/rst/guide/development/cicd.rst
@@ -57,8 +57,8 @@ Workflow Template Structure
        steps:
          - uses: actions/checkout@<SHA> # v4
 
-CI Workflow (ci.yml)
---------------------
+CI Workflow (pull-request.yml, merge.yml)
+-----------------------------------------
 
 Standard Linting Workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -287,13 +287,18 @@ Complete workflow implementing the :ref:`standards` CI architecture.
 
 **Architecture:** See :ref:`standards` for CI workflow structure diagram.
 
-CodeQL Workflow (codeql.yml)
------------------------------
+CodeQL Workflow (nightly-security.yml)
+--------------------------------------
 
 Security Scanning
 ~~~~~~~~~~~~~~~~~
 
 **Required for all public repositories** (see :ref:`standards`).
+
+CodeQL is not a workflow of its own in a project repository: the
+``nightly-security.yml`` caller invokes the shared ``security-code.yml``
+alongside the other scans. The example below shows the analysis steps that
+workflow performs.
 
 .. code-block:: yaml
 
@@ -343,8 +348,8 @@ Security Scanning
 Deploy/Publish Workflow
 -----------------------
 
-For Docker/Actions (deploy.yml)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For Docker/Actions (tag.yml)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
@@ -404,8 +409,8 @@ For Docker/Actions (deploy.yml)
 * Publishes to GitHub Container Registry
 * Creates GitHub Release with auto-generated notes
 
-For Ansible Collections (publish.yml)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For Ansible Collections (tag.yml)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Implementation of** :ref:`standards` **publish requirements.**
 

--- a/rst/guide/development/contributing.rst
+++ b/rst/guide/development/contributing.rst
@@ -270,7 +270,7 @@ Release Process
 
 4. **Automated workflows trigger**
 
-   * ``publish.yml`` publishes to Ansible Galaxy (see :ref:`cicd` for workflow details)
+   * ``tag.yml`` publishes to Ansible Galaxy (see :ref:`cicd` for workflow details)
    * Creates GitHub Release with CHANGELOG notes
 
 Go Project Standards


### PR DESCRIPTION
## Summary

- The guide prescribed `ci.yml`, `publish.yml`, `security.yml` and `codeql.yml`. No repository in the organisation uses those names, so the rule produced drift findings against a convention that never existed in practice.
- Documents the two layers that are actually in use instead: reusable workflows in `arillso/.github` named `<category>-<purpose>.yml` (`ci-*`, `security-*`, `release-*`, `cleanup-*`, `ai-*`), and event-focused callers in each project repo (`pull-request.yml`, `merge.yml`, `tag.yml`, `nightly-security.yml`, `cleanup.yml`).
- Also corrects the follow-on references in `cicd.rst` (section headings for CI, CodeQL and publish workflows) and `contributing.rst`, which named the same non-existent files. CodeQL is noted as folded into `nightly-security.yml` rather than a standalone workflow.

Further occurrences (not adjusted): `deploy.yml` appears in `rst/index.rst`, `rst/github/`, `rst/libraries/`, and the tutorial pages. Those are Ansible playbook filenames and consumer-side examples of calling `arillso/action.playbook` from a user's own repository, not workflow names governed by this convention.

## Test plan

- [ ] CI documentation build passes (nitpicky Sphinx build via `build.sh`)
- [ ] Link check passes, including the new external link to `arillso/.github`
- [ ] No occurrences of the prescriptive flat names remain: `rg -e 'ci\.yml' -e 'publish\.yml' -e 'security\.yml' -e 'codeql\.yml' rst/`