### PR TITLE
chore(repo): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner
+* @sbaerlocher


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with `* @sbaerlocher`, matching the byte-identical file shipped by the other code repositories in this org.
- The repository's own standards guide lists CODEOWNERS as a required file (`rst/guide/best-practices/standards.rst:34`, content specified at `:141`), and the published CI templates already reference it via `paths-ignore` (`rst/guide/development/cicd.rst:42`, `:78`, `:159`, `:800`) — but the file was missing here.

## Test plan

- [ ] CI green
- [ ] GitHub resolves the file as a valid CODEOWNERS (no syntax warning on the PR)