### PR TITLE
fix(versions): bump arillso collection pins and let Renovate track them

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,10 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>arillso/.github:renovate-base"
-    ],
+    "extends": ["github>arillso/.github:renovate-base"],
     "customManagers": [
         {
             "customType": "regex",
-            "managerFilePatterns": [
-                "/^build\\.sh$/"
-            ],
+            "managerFilePatterns": ["/^build\\.sh$/", "/^versions\\.env$/"],
             "matchStrings": [
                 "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n[A-Z_]+=\"(?<currentValue>[^\"]+)\""
             ],

--- a/rst/guide/reference/compatibility.rst
+++ b/rst/guide/reference/compatibility.rst
@@ -28,15 +28,15 @@ Current Release Status
      - Status
      - End of Life
    * - arillso.system
-     - 1.0.x
+     - 1.1.x
      - Supported
      - TBD
    * - arillso.container
-     - 1.0.x
+     - 1.4.x
      - Supported
      - TBD
    * - arillso.agent
-     - 1.0.x
+     - 1.2.x
      - Supported
      - TBD
    * - arillso/ansible (container)

--- a/versions.env
+++ b/versions.env
@@ -1,7 +1,7 @@
 # Collection versions - managed by Renovate
 # renovate: datasource=galaxy-collection depName=arillso.system
-ARILLSO_SYSTEM_VERSION="1.0.5"
+ARILLSO_SYSTEM_VERSION="1.1.6"
 # renovate: datasource=galaxy-collection depName=arillso.agent
-ARILLSO_AGENT_VERSION="1.0.3"
+ARILLSO_AGENT_VERSION="1.2.0"
 # renovate: datasource=galaxy-collection depName=arillso.container
-ARILLSO_CONTAINER_VERSION="1.0.2"
+ARILLSO_CONTAINER_VERSION="1.4.0"


### PR DESCRIPTION
## Summary

- `versions.env` pinned `arillso.system` at `1.0.5` while the collection is at `1.1.6`, so the site was built from a stale collection. Pins raised to `1.1.6` / `1.2.0` / `1.4.0` (latest published tags).
- Root cause of the drift: the `customManager` in `.github/renovate.json` matched only `/^build\.sh$/`, but the pins live in `versions.env`, and `.env` is not covered by the base preset's managers either. Added `/^versions\.env$/` so Renovate keeps them current; `matchStrings` was already compatible and needed no change.
- Corrected the three stale `1.0.x` rows in the compatibility table (`rst/guide/reference/compatibility.rst`), where `container` was four minor versions behind.

The `zram` role documentation is deliberately **not** fixed here: the role exists in `arillso/ansible.system` only on `main` under `[Unreleased]`, and the build installs published versions via `ansible-galaxy`. It stays missing until upstream cuts a release containing it.

## Test plan

- [ ] CI `build-docs` runs `./build.sh`, ending in `sphinx-build … -W --keep-going`, so an unresolvable collection version or a broken `list-table` fails the job. The build toolchain could not run locally (`antsibull-docs`/`sphinx-build` absent, Galaxy unreachable), so CI is the verifying gate.
- [x] Renovate regex re-run against the real `versions.env`: 3 matches, datasource `galaxy-collection`, depNames `arillso.system` / `arillso.agent` / `arillso.container`.
- [x] `python3 -m json.tool` and `prettier --check` clean on `.github/renovate.json`; compatibility table rows still have 4 cells each.
- [x] Target versions confirmed as the latest tags of the three upstream repos.