### PR TITLE
fix(license): add MIT License header line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2020-2026 Arillso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Summary

- Prepend the `MIT License` header line plus a blank line to `LICENSE`, which previously started directly with the copyright line
- The repository standards published in this repo (`rst/guide/best-practices/standards.rst`) specify exactly this format

## Test plan

- [ ] `LICENSE` starts with `MIT License`, blank line, then the unchanged copyright line
- [ ] CI green