### PR TITLE
ci: run CodeQL for python and javascript

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -16,7 +16,18 @@ permissions:
     contents: read
     actions: read
     pull-requests: read
+    security-events: write
 
 jobs:
+    codeql-python:
+        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
+        with:
+            language: python
+
+    codeql-javascript:
+        uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
+        with:
+            language: javascript
+
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-18

--- a/rst/guide/development/cicd.rst
+++ b/rst/guide/development/cicd.rst
@@ -316,20 +316,22 @@ repository with several analysable languages calls it once per language:
 The caller must also grant ``security-events: write``, otherwise the reusable
 cannot upload its results.
 
-The example below shows the analysis steps that workflow performs.
+The example below shows the analysis steps that workflow performs for the
+language it was called with.
 
 .. code-block:: yaml
 
    ---
-   name: CodeQL Analysis
+   name: Security - CodeQL
 
    on:
-     push:
-       branches: [main]
-     pull_request:
-       branches: [main]
-     schedule:
-       - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
+     workflow_call:
+       inputs:
+         language:
+           description: 'Language to analyze (go, javascript, python, etc.)'
+           required: false
+           type: string
+           default: 'go'
 
    permissions:
      security-events: write
@@ -337,30 +339,33 @@ The example below shows the analysis steps that workflow performs.
 
    jobs:
      analyze:
-       name: Analyze Code
+       name: Analyze
        runs-on: ubuntu-latest
        strategy:
+         fail-fast: false
          matrix:
-           language: [go, python, javascript]
+           language: ['${{ inputs.language }}']
        steps:
-         - name: Checkout Code
-           uses: actions/checkout@<SHA> # v4
+         - name: Checkout repository
+           uses: actions/checkout@<SHA> # v7
 
          - name: Initialize CodeQL
-           uses: github/codeql-action/init@<SHA> # v3
+           uses: github/codeql-action/init@<SHA> # v4
            with:
              languages: ${{ matrix.language }}
 
          - name: Autobuild
-           uses: github/codeql-action/autobuild@<SHA> # v3
+           uses: github/codeql-action/autobuild@<SHA> # v4
 
          - name: Perform CodeQL Analysis
-           uses: github/codeql-action/analyze@<SHA> # v3
+           uses: github/codeql-action/analyze@<SHA> # v4
+           with:
+             category: "/language:${{ matrix.language }}"
 
 **Features:**
 
-* Weekly scheduled scans (Monday 06:00 UTC)
-* Multi-language support (Go, Python, JavaScript)
+* Runs on the caller's schedule (``nightly-security.yml``)
+* One language per call, so callers add a job per analysable language
 * Automatic SARIF upload to GitHub Security
 
 Deploy/Publish Workflow

--- a/rst/guide/development/cicd.rst
+++ b/rst/guide/development/cicd.rst
@@ -296,9 +296,27 @@ Security Scanning
 **Required for all public repositories** (see :ref:`standards`).
 
 CodeQL is not a workflow of its own in a project repository: the
-``nightly-security.yml`` caller invokes the shared ``security-code.yml``
-alongside the other scans. The example below shows the analysis steps that
-workflow performs.
+``nightly-security.yml`` caller invokes the shared ``security-codeql.yml``
+alongside the other scans. The reusable analyses one language per call, so a
+repository with several analysable languages calls it once per language:
+
+.. code-block:: yaml
+
+   jobs:
+     codeql-python:
+       uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
+       with:
+         language: python
+
+     codeql-javascript:
+       uses: arillso/.github/.github/workflows/security-codeql.yml@2026-06-18
+       with:
+         language: javascript
+
+The caller must also grant ``security-events: write``, otherwise the reusable
+cannot upload its results.
+
+The example below shows the analysis steps that workflow performs.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## Summary

- Hook the shared `security-codeql.yml` reusable into `nightly-security.yml`; it was never called, so no static analysis ran on this repository despite it shipping python and javascript sources.
- The reusable analyses one language per call, so it is called twice (`python`, `javascript`). The caller now also grants `security-events: write`, without which the reusable cannot upload results.
- Fix the CI docs, which named a non-existent reusable (`security-code.yml`) and showed a language matrix the reusable does not support.

## Test plan

- [ ] `actionlint`, `yamllint`, `gitleaks` and `prettier` pass locally (lefthook pre-commit green)
- [ ] CI green
- [ ] After merge: the next `Nightly Security Scan` run shows the `codeql-python` and `codeql-javascript` jobs and uploads results to the Security tab