### PR TITLE
docs(standards): exempt repos without CodeQL-supported code

### DIFF
--- a/rst/guide/best-practices/standards.rst
+++ b/rst/guide/best-practices/standards.rst
@@ -239,7 +239,8 @@ Caller workflows in a project repository:
      - Publish to registry + GitHub Release
    * - Schedule
      - ``nightly-security.yml``
-     - Security scanning, including CodeQL (required for public repos)
+     - Security scanning, including CodeQL (required for public repos with
+       CodeQL-supported code)
    * - Schedule
      - ``cleanup.yml``
      - Registry retention cleanup (only where a registry is used)
@@ -249,6 +250,42 @@ something to release, ``cleanup.yml`` only where a container registry is used.
 
 The reusable workflows these callers invoke are listed in
 `arillso/.github <https://github.com/arillso/.github>`_.
+
+.. _codeql-exception:
+
+CodeQL Exception
+~~~~~~~~~~~~~~~~
+
+CodeQL is required for public repositories **that contain code CodeQL can
+analyse**. A repository whose tree holds no file with a CodeQL-supported
+extension is exempt: there is nothing for the analysis to read, so the scan
+would either fail to configure or report an empty result forever.
+
+The test is the tree, not a maintained list of exempt repositories. It covers
+the compiled and interpreted languages ``security-code.yml`` is configured for
+via its ``languages`` input:
+
+.. code-block:: bash
+
+   # Exempt if this finds nothing
+   git ls-files -- '*.go' '*.py' '*.pyw' '*.js' '*.mjs' '*.cjs' '*.jsx' \
+     '*.ts' '*.tsx' '*.java' '*.cs' '*.c' '*.h' '*.cpp' '*.cc' '*.cxx' \
+     '*.hpp' '*.hh' '*.rb' '*.swift' '*.kt' '*.kts'
+
+CodeQL also ships an ``actions`` language that analyses
+``.github/workflows/*.yml``. It is deliberately **not** part of this test:
+``security-code.yml`` does not enable it, so workflow files alone do not make a
+repository subject to the criterion. Wiring up Actions analysis is a separate
+decision — until it happens, a repository with nothing but workflows and prose
+stays exempt.
+
+Pure Ansible Collections and pure documentation repositories are the usual
+case. Such a repository still runs ``nightly-security.yml``; its caller invokes
+the scans that do apply — at minimum ``security-secrets.yml`` — and omits
+``security-code.yml``.
+
+Adding a file in a supported language removes the exemption — the criterion is
+re-evaluated per audit, not granted once.
 
 GitHub Actions Security
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/rst/guide/development/cicd.rst
+++ b/rst/guide/development/cicd.rst
@@ -293,7 +293,8 @@ CodeQL Workflow (nightly-security.yml)
 Security Scanning
 ~~~~~~~~~~~~~~~~~
 
-**Required for all public repositories** (see :ref:`standards`).
+**Required for all public repositories that contain CodeQL-supported code**
+(see :ref:`codeql-exception` for the exemption and how it is tested).
 
 CodeQL is not a workflow of its own in a project repository: the
 ``nightly-security.yml`` caller invokes the shared ``security-codeql.yml``


### PR DESCRIPTION
## Summary

- The CodeQL rule required the scan for every public repository, including ones with no analysable source. Pure Ansible Collections and documentation repos could never satisfy it, so the criterion produced a permanent audit deviation instead of a finding worth acting on.
- Adds a `CodeQL Exception` subsection under Workflow Standards defining the exemption and how it is tested: a `git ls-files` check over the CodeQL-supported extensions, so the rule is evaluated against the tree rather than a hand-maintained list of exempt repositories.
- Updates the two normative statements (`standards.rst` caller table, `cicd.rst` security scanning) to match; the exempt repo still runs `nightly-security.yml` with the scans that do apply and omits `security-code.yml`.

## Test plan

- [ ] Sphinx build succeeds in CI
- [ ] The new `codeql-exception` label resolves from the `:ref:` in `cicd.rst` (verified locally against all 143 `:ref:` uses in `rst/`)