### PR TITLE
fix(scripts): classify external links by hostname instead of substring

### DIFF
--- a/src/scripts/features/external-links.js
+++ b/src/scripts/features/external-links.js
@@ -18,12 +18,31 @@ export function initExternalLinks() {
   });
 }
 
+// Matches a host exactly or as a subdomain, so that a lookalike such as
+// `github.com.example.org` or a bare substring in a query parameter does
+// not get classified as the real destination.
+function hostMatches(hostname, domain) {
+  return hostname === domain || hostname.endsWith("." + domain);
+}
+
 function getExternalLinkDestination(url) {
-  if (url.includes("github.com/marketplace")) return "GitHub Actions";
-  if (url.includes("github.com")) return "GitHub";
-  if (url.includes("hub.docker.com")) return "Docker Hub";
-  if (url.includes("galaxy.ansible.com")) return "Ansible Galaxy";
-  if (url.includes("arillso.io")) return "Arillso Website";
+  let parsed;
+  try {
+    parsed = new URL(url, document.baseURI);
+  } catch {
+    return "Other";
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (hostMatches(host, "github.com")) {
+    return parsed.pathname.startsWith("/marketplace")
+      ? "GitHub Actions"
+      : "GitHub";
+  }
+  if (hostMatches(host, "hub.docker.com")) return "Docker Hub";
+  if (hostMatches(host, "galaxy.ansible.com")) return "Ansible Galaxy";
+  if (hostMatches(host, "arillso.io")) return "Arillso Website";
   return "Other";
 }
 


### PR DESCRIPTION
## Summary

- Clears the four open CodeQL alerts for `js/incomplete-url-substring-sanitization` in `src/scripts/features/external-links.js`. A bare `url.includes("github.com")` also matches `github.com.example.org` or a query parameter that merely contains the string.
- The destination value only labels an analytics event and gates no navigation or trust decision, so nothing here was exploitable. The classification was simply wrong for those URLs.
- Parses the URL and compares the hostname exactly or as a subdomain. `github.com/marketplace` is now distinguished by pathname rather than by substring order, which also removes the ordering dependency between the first two branches.

## Test plan

- [ ] CI green, in particular the Build Documentation check and CodeQL
- [ ] `npm run build` bundles without error
- [ ] Classification verified locally against real and lookalike URLs:
  - `https://github.com/arillso/guide` → GitHub
  - `https://github.com/marketplace/actions/x` → GitHub Actions
  - `https://www.github.com/arillso` → GitHub
  - `https://guide.arillso.io/x` → Arillso Website
  - `https://github.com.evil.org/x` → Other
  - `https://evil.com/?redir=github.com` → Other
  - `https://notgithub.com/x` → Other