### PR TITLE
refactor(yamllint): rename config to .yamllint.yml and match published standard

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,7 +3,7 @@ extends: default
 
 rules:
     line-length:
-        max: 160
+        max: 500
         level: warning
 
     comments:
@@ -17,7 +17,7 @@ rules:
         check-multi-line-strings: false
 
     truthy:
-        allowed-values: ['true', 'false']
+        allowed-values: ["true", "false", "on"]
         check-keys: false
 
     brackets:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ documentation toolchain only.
 ### Code Style
 
 - Use 4 spaces for indentation in YAML and JSON files (see `.editorconfig`)
-- Markdown follows `.markdownlint.json`; YAML follows `.yamllint`
+- Markdown follows `.markdownlint.json`; YAML follows `.yamllint.yml`
 - Run hooks locally with `lefthook install`; they run on commit and push
 
 ### Building

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,7 +21,7 @@ pre-commit:
         yamllint:
             glob: "*.{yml,yaml}"
             exclude: "(^build/|^temp-rst/|^rst/collections/)"
-            run: yamllint -c .yamllint {staged_files}
+            run: yamllint -c .yamllint.yml {staged_files}
         markdownlint:
             glob: "*.md"
             exclude: "(^build/|^temp-rst/|^rst/collections/)"


### PR DESCRIPTION
## Summary

- Rename `.yamllint` to `.yamllint.yml` via `git mv`, matching the name this repository publishes in `rst/guide/best-practices/standards.rst`, `rst/guide/development/cicd.rst` and `rst/guide/getting-started/environment.rst`
- Align the two diverging values with the published standard: `line-length.max` 160 to 500, and `"on"` added to `truthy.allowed-values`. The published text is unchanged; the config follows it
- Pull the two references along in the same commit (`lefthook.yml`, `AGENTS.md`) so the pre-commit hook stays resolvable at every point in history

All 16 rules, all 10 ignores (including the repo-specific `build/`, `temp-rst/`, `rst/collections/`) and `line-length.level: warning` are kept.

## Test plan

- [x] `yamllint -c .yamllint .` before the change: exit 0, two `document-start` warnings (`docker-compose.yml`, `.dde/config.yml`)
- [x] `yamllint -c .yamllint.yml .` after the change: exit 0, the same two warnings — behaviour-neutral. Both warnings pre-date this change
- [x] No remaining reference to the old filename: `rg '\.yamllint(?!\.yml)' --pcre2` returns nothing
- [x] `git diff --cached --stat -M` shows `.yamllint => .yamllint.yml` as a rename, not delete plus add
- [x] lefthook pre-commit ran on commit (gitleaks, yamllint, prettier, markdownlint all green), proving `lefthook.yml` resolves the new path