### PR TITLE
docs(editorconfig): align documented YAML indent size with actual configs

### DIFF
--- a/rst/guide/development/cicd.rst
+++ b/rst/guide/development/cicd.rst
@@ -610,7 +610,7 @@ EditorConfig (.editorconfig)
    indent_size = 4
 
    [*.{yml,yaml}]
-   indent_size = 2
+   indent_size = 4
 
    [*.md]
    trim_trailing_whitespace = false

--- a/rst/guide/getting-started/environment.rst
+++ b/rst/guide/getting-started/environment.rst
@@ -304,8 +304,8 @@ The .editorconfig file helps maintain a consistent coding style. Below is an exa
 
     # Specific settings for YAML files.
     [*.yml]
-    # Sets the indentation size for YAML files to 2 spaces.
-    indent_size = 2
+    # Sets the indentation size for YAML files to 4 spaces.
+    indent_size = 4
 
 .pre-commit-config.yaml for Ansible
 -----------------------------------
@@ -362,7 +362,7 @@ Maintains consistent coding style across editors and IDEs:
    insert_final_newline = true
 
    [*.{yml,yaml}]
-   indent_size = 2
+   indent_size = 4
 
    [*.md]
    trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

- Three `.editorconfig` examples in the guide documented `indent_size = 2` for YAML while every `.editorconfig` in the organization sets 4, so the guide contradicted the repositories it describes.
- Corrected all three occurrences to 4 (`cicd.rst`, `environment.rst` twice), including the explanatory comment next to one of them. Documentation follows reality here — the reverse would reformat every YAML file in the organization.

## Test plan

- [ ] Sphinx documentation build passes (CI)
- [ ] `rg -n 'indent_size' rst/` reports 4 for every occurrence