### PR TITLE
docs: align documented scan cadence with the daily schedule

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -5,7 +5,7 @@ run-name: |
 
 on:
     schedule:
-        - cron: "0 2 * * *"
+        - cron: "0 2 * * *" # Daily 02:00 UTC (public repo — Actions minutes are free)
     workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Event-focused workflows calling reusables from `arillso/.github`:
 - **pull-request.yml** (`Pull Request`) - builds the docs, runs the secret
   scan, and runs Claude review on PRs
 - **merge.yml** (`Merge to Main`) - builds and deploys to Pages on push to
-  `main` and the weekly schedule, plus the secret scan
+  `main`, plus the secret scan
 - **nightly-security.yml** (`Nightly Security Scan`) - scheduled secret scan
 
 ## Do Not

--- a/rst/guide/best-practices/standards.rst
+++ b/rst/guide/best-practices/standards.rst
@@ -303,7 +303,7 @@ See :ref:`cicd` for implementation details and examples.
 Schedule Frequency
 ~~~~~~~~~~~~~~~~~~
 
-Scheduled workflows run **weekly on Monday at 06:00 UTC**.
+Scheduled security workflows run **daily at 02:00 UTC**.
 
 See :ref:`cicd` for workflow implementation examples.
 


### PR DESCRIPTION
## Summary

- `standards.rst` claimed scheduled workflows run weekly on Monday at 06:00 UTC; the actual schedule is daily at 02:00 UTC, matching every other repo in the org that ships `nightly-security.yml`
- `AGENTS.md` described `merge.yml` as running on a weekly schedule, which no longer exists — that workflow only triggers on push to `main` and `workflow_dispatch`
- Added the inline rationale behind the cron in `nightly-security.yml`, wording matched to the six neighbouring repos

No behaviour changes: the cron value itself is untouched, only a trailing comment was added.

## Test plan

- [ ] `Build Documentation` job green (`./build.sh`)
- [ ] `linkcheck` green — no `:ref:` target or link was touched
- [ ] Secret scan green