### PR TITLE
chore(renovate): pin preset extends to date tag 2026-08-08

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>arillso/.github:renovate-base"],
+    "extends": ["github>arillso/.github:renovate-base#2026-08-08"],
     "customManagers": [
         {
             "customType": "regex",


### PR DESCRIPTION
## Summary

- Pin the Renovate preset ref in `.github/renovate.json` to `github>arillso/.github:renovate-base#2026-08-08`. Without a ref the preset resolved against the default branch of `arillso/.github`, so any push there changed this repo's dependency behaviour with no PR and no trace in this repo's history.
- The pinned form is also what the customManager in `renovate-base` matches, so the tag is kept current automatically from here on.

## Test plan

- [x] `jq empty .github/renovate.json` exits 0
- [x] Diff is a single line change, `customManagers` block untouched
- [ ] After merge: dependency dashboard still resolves the preset and dependency PRs keep appearing